### PR TITLE
chore: switch deploy auth from KUBECONFIG_DATA to Tailscale

### DIFF
--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -51,7 +51,22 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@master
 
+      - name: Parse Tailscale OAuth secret
+        env:
+          TAILSCALE_OAUTH: ${{ secrets.TAILSCALE_OAUTH }}
+        run: |
+          echo "TS_CLIENT_ID=$(printf '%s\n' "$TAILSCALE_OAUTH" | sed -n 's/^client_id: *//p')" >> "$GITHUB_ENV"
+          echo "TS_SECRET=$(printf '%s\n' "$TAILSCALE_OAUTH"   | sed -n 's/^client_secret: *//p')" >> "$GITHUB_ENV"
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ env.TS_CLIENT_ID }}
+          oauth-secret: ${{ env.TS_SECRET }}
+          tags: tag:sminnee-prod-deploy
+
+      - name: Configure kubeconfig over tailnet
+        run: tailscale configure kubeconfig tailscale-operator
+
       - name: Update Kubernetes deployment
         run: bin/deploy $(echo $GITHUB_SHA | head -c7)
-        env:
-          KUBECONFIG_DATA: ${{ secrets.KUBECONFIG_DATA }}

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Deploys manifests from k8s/ directory to sminnee-prod namespace.
-# Reads cluster credentials from KUBECONFIG_DATA (a complete kubeconfig YAML
-# with CA + client cert + key inline). Provisioned and rotated by
-# k8s-cluster's bin/secretmgr; pushed to this repo's GitHub Actions secrets.
+# Cluster access is via the active kubeconfig context. In CI this is set up by
+# `tailscale configure kubeconfig` pointing kubectl at the tailscale-operator
+# API-server proxy over the tailnet.
 
 NAMESPACE=sminnee-prod
 DEPLOYMENT=www
@@ -12,17 +12,6 @@ if [ "$1" = "" ]; then
     echo "Usage: $0 (tag)"
     exit 1
 fi
-
-if [ "$KUBECONFIG_DATA" = "" ]; then
-  echo "Set KUBECONFIG_DATA env var to a complete kubeconfig YAML for cluster access"
-  exit 2
-fi
-
-KUBECONFIG_FILE=$(mktemp)
-chmod 600 "$KUBECONFIG_FILE"
-echo "$KUBECONFIG_DATA" > "$KUBECONFIG_FILE"
-export KUBECONFIG="$KUBECONFIG_FILE"
-trap 'rm -f "$KUBECONFIG_FILE"' EXIT
 
 # Apply all manifests with image tag substitution
 export IMAGE_TAG="$1"


### PR DESCRIPTION
Join the tailnet as an ephemeral node and reach the cluster via the tailscale-operator API-server proxy, replacing the inline kubeconfig secret.

- test-and-deploy.yaml: parse TAILSCALE_OAUTH, connect via tailscale/github-action@v3 (tag:sminnee-prod-deploy), configure kubeconfig over the tailnet; drop KUBECONFIG_DATA env.
- bin/deploy: use the active kubeconfig context; remove the KUBECONFIG_DATA guard, mktemp write, and trap cleanup.